### PR TITLE
Makefile: fix bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,16 @@ outputsdir:
 
 bootstrap:
 	git clone git@github.com:fifteenhex/linux.git
-	git -C linux --track origin/msc313e_dev_v5_6_rebase
+	git -C linux checkout --track origin/msc313e_dev_v5_6_rebase
 	cp linux.config linux/.config
 	git clone git@github.com:breadbee/u-boot.git
-	git -C u-boot --track origin/m5iplwork
+	git -C u-boot checkout --track origin/m5iplwork
 	git clone git@github.com:breadbee/breadbee_buildroot.git $(BBBUILDROOT)
 	$(MAKE) -C $(BBBUILDROOT) bootstrap
 	git clone git@github.com:fifteenhex/mstarblobs.git
 
 	git clone git@github.com:fifteenhex/buildroot_mercury5.git $(M5BUILDROOT)
-	$(MAKE) -C $(M5BUILDROOT)
+	$(MAKE) -C $(M5BUILDROOT) bootstrap
 
 linux:
 	- rm linux/arch/arm/boot/zImage


### PR DESCRIPTION
The bootstrap target is broken. The two git invocations are missing the
"checkout" command and the last make invocation tries to build the m5
buildroot instead of boostraping it.