### PR TITLE
Makefile: fix kernel.fit usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILDROOT=$(BBBUILDROOT)/buildroot
 	linux \
 	upload \
 	outputsdir \
-	kernel.fit \
+	kernel_m5.fit \
 	rtk \
 	squeekyclean
 
@@ -141,7 +141,7 @@ vendor.fit: outputsdir
 
 
 clean: linux_clean
-	rm -rf kernel.fit nor nor_ipl
+	rm -rf kernel_m5.fit nor nor_ipl
 
 push_linux_config:
 	cp linux/.config ../breadbee_buildroot/br2breadbee/board/thingyjp/breadbee/linux.config
@@ -156,10 +156,10 @@ fix_brick_spl:
 
 RTKPADBYTES=512
 
-rtk: uboot_m5 kernel.fit
+rtk: uboot_m5 kernel_m5.fit
 	dd if=/dev/zero of=rtk bs=1K count=$(RTKPADBYTES)
 	dd conv=notrunc if=u-boot/u-boot.bin of=rtk
-	dd conv=notrunc if=kernel.fit of=rtk bs=1k seek=$(RTKPADBYTES)
+	dd conv=notrunc if=kernel_m5.fit of=rtk bs=1k seek=$(RTKPADBYTES)
 	mv rtk $(OUTPUTS)/rtk
 
 squeekyclean:

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ the IPL.
 make spl
 ```
 
-### kernel.fit
+### kernel_m5.fit
 
 This builds a kernel FIT image *without* the breadbee overlays but *with* the breadbee rescue initramfs.
 This is mainly for testing on mercury5 where actually writing the rootfs to the SPI NOR would
 destroy the existing firmware that is still useful for making sure the screen etc are still working.
 
 ```
-make kernel.fit
+make kernel_m5.fit
 ```
 ### kernel_breadbee.fit
 


### PR DESCRIPTION
The "more m5 splitting commit removed the kernel.fit target replacing it
with kernel_m5.fit. Unfortunately this brakes the rtk target as the
kernel.fit can no longer be found.

This patch updates parts of the Makefile to fix the problem however I'm
not replacing all kernel.fit accesses as I'm not sure if nor and nor_ipl
targets should use the m5 or breadbee kernel image.